### PR TITLE
chore(lib): force u32 for generate_path_candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "differt-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "numpy",
  "pyo3",

--- a/differt-core/Cargo.toml
+++ b/differt-core/Cargo.toml
@@ -16,4 +16,4 @@ name = "differt_core"
 [package]
 edition = "2021"
 name = "differt-core"
-version = "0.0.2"
+version = "0.0.3"

--- a/differt-core/src/lib.rs
+++ b/differt-core/src/lib.rs
@@ -4,30 +4,26 @@ use pyo3::prelude::*;
 
 /// Formats the sum of two numbers as string.
 #[pyfunction]
-fn generate_path_candidates(
-    py: Python<'_>,
-    num_primitives: usize,
-    order: usize,
-) -> &PyArray2<usize> {
+fn generate_path_candidates(py: Python<'_>, num_primitives: u32, order: u32) -> &PyArray2<u32> {
     if num_primitives == 0 || order == 0 {
         return Array2::default((0, 0)).into_pyarray(py);
     } else if order == 1 {
-        let mut path_candidates = Array2::default((1, num_primitives));
+        let mut path_candidates = Array2::default((1, num_primitives as usize));
 
         for i in 0..num_primitives {
-            path_candidates[(0, i)] = i;
+            path_candidates[(0, i as usize)] = i;
         }
         return path_candidates.into_pyarray(py);
     }
-    let num_choices = num_primitives - 1;
-    let num_candidates_per_batch = num_choices.pow((order - 1) as u32);
-    let num_candidates = num_primitives * num_candidates_per_batch;
+    let num_choices = (num_primitives - 1) as usize;
+    let num_candidates_per_batch = num_choices.pow(order - 1);
+    let num_candidates = (num_primitives as usize) * num_candidates_per_batch;
 
-    let mut path_candidates = Array2::default((order, num_candidates));
+    let mut path_candidates = Array2::default((order as usize, num_candidates));
     let mut batch_size = num_candidates_per_batch;
     let mut fill_value = 0;
 
-    for i in 0..order {
+    for i in 0..(order as usize) {
         for j in (0..num_candidates).step_by(batch_size) {
             if i > 0 && fill_value == path_candidates[(i - 1, j)] {
                 fill_value = (fill_value + 1) % num_primitives;
@@ -59,16 +55,16 @@ mod tests {
 
     use pyo3::{types::IntoPyDict, Python};
 
-    #[rstest] // TODO: FIXME on Windows because uint is not consistent
-    #[case(0, 0, "np.empty((0, 0), dtype=np.uint)")]
-    #[case(3, 0, "np.empty((0, 0), dtype=np.uint)")]
-    #[case(0, 3, "np.empty((0, 0), dtype=np.uint)")]
-    #[case(9, 1, "np.arange(9, dtype=np.uint).reshape(1, 9)")]
-    #[case(3, 1, "np.array([[0, 1, 2]], dtype=np.uint)")]
+    #[rstest]
+    #[case(0, 0, "np.empty((0, 0), dtype=np.uint32)")]
+    #[case(3, 0, "np.empty((0, 0), dtype=np.uint32)")]
+    #[case(0, 3, "np.empty((0, 0), dtype=np.uint32)")]
+    #[case(9, 1, "np.arange(9, dtype=np.uint32).reshape(1, 9)")]
+    #[case(3, 1, "np.array([[0, 1, 2]], dtype=np.uint32)")]
     #[case(
         3,
         2,
-        "np.array([[0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1]], dtype=np.uint).T"
+        "np.array([[0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1]], dtype=np.uint32).T"
     )]
     #[case(
         3,
@@ -87,19 +83,19 @@ mod tests {
                 [2, 0, 1],
                 [2, 1, 2],
                 [2, 1, 0],
-            ], dtype=np.uint
+            ], dtype=np.uint32
         ).T"
     )]
     fn test_generate_path_candidates(
-        #[case] num_primitives: usize,
-        #[case] order: usize,
+        #[case] num_primitives: u32,
+        #[case] order: u32,
         #[case] code: &str,
     ) {
         Python::with_gil(|py| {
             let np = py.import("numpy").unwrap();
             let locals = [("np", np)].into_py_dict(py);
             let got = generate_path_candidates(py, num_primitives, order);
-            let expected: &PyArray2<usize> = py
+            let expected: &PyArray2<u32> = py
                 .eval(code, Some(locals), None)
                 .unwrap()
                 .extract()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/jeertmans/DiffeRT"
-version = "0.0.2"
+version = "0.0.3"
 
 [tool.poetry.dependencies]
 chex = "^0.1.84"


### PR DESCRIPTION
See why here: https://github.com/PyO3/rust-numpy/issues/404.