### PR TITLE
fix(ci): update CI to match upload-artifact v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-linux-${{ matrix.target }}
         path: dist
 
   windows:
@@ -64,7 +64,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-windows-${{ matrix.target }}
         path: dist
 
   macos:
@@ -91,7 +91,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-macos-${{ matrix.target }}
         path: dist
 
   sdist:
@@ -109,7 +109,7 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-sdist
         path: dist
 
   release:
@@ -123,11 +123,9 @@ jobs:
     steps:
     - name: Download build wheels
       uses: actions/download-artifact@v4
-      with:
-        name: wheels
 
     - name: Publish to PyPI
       uses: PyO3/maturin-action@v1
       with:
         command: upload
-        args: --non-interactive --skip-existing *
+        args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact and https://github.com/PyO3/maturin/pull/1886.
