### PR TITLE
chore(docs): remove specific kernel

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,6 @@ build:
   jobs:
     post_system_dependencies:
     - nohup Xvfb $DISPLAY -screen 0 1400x900x24 -dpi 96 +extension RANDR +render &
-    post_install:
-    - ipython kernel install --name "DiffeRT" --user
 sphinx:
   builder: dirhtml
   configuration: docs/source/conf.py

--- a/README.md
+++ b/README.md
@@ -55,21 +55,7 @@ pdm install
 
 ### Documentation
 
-To generate the documentation, you first need to install an IPython kernel named
-`DiffeRT`:
-
-```bash
-pdm run ipython kernel install --user --name=DiffeRT
-```
-
-If you want to use another name for your kernel, please also modify the
-name in [`docs/source/conf.py`](docs/source/conf.py):
-
-```python
-nb_kernel_rgx_aliases = {".*": "DiffeRT"}
-```
-
-Then, you can build the docs with:
+To generate the documentation, please run the following:
 
 ```bash
 cd docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,6 @@ always_document_param_types = True
 # -- MyST-nb settings
 myst_heading_anchors = 3
 
-nb_kernel_rgx_aliases = {".*": "DiffeRT"}  # TODO: do not require specific kernel name
 nb_merge_streams = True
 
 # By default, MyST-nb chooses the Widget output instead of the 2D snapshot

--- a/docs/source/notebooks/advanced_path_tracing.ipynb
+++ b/docs/source/notebooks/advanced_path_tracing.ipynb
@@ -127,9 +127,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DiffeRT",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "differt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/source/notebooks/performance_tips.ipynb
+++ b/docs/source/notebooks/performance_tips.ipynb
@@ -192,9 +192,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DiffeRT",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "differt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/source/notebooks/plotting_backend.ipynb
+++ b/docs/source/notebooks/plotting_backend.ipynb
@@ -200,9 +200,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DiffeRT",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "differt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/source/notebooks/quickstart.ipynb
+++ b/docs/source/notebooks/quickstart.ipynb
@@ -233,9 +233,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DiffeRT",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "differt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/source/notebooks/ray_tracing_at_city_scale.ipynb
+++ b/docs/source/notebooks/ray_tracing_at_city_scale.ipynb
@@ -148,9 +148,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DiffeRT",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "differt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/source/notebooks/type_checking.ipynb
+++ b/docs/source/notebooks/type_checking.ipynb
@@ -199,9 +199,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DiffeRT",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "differt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Seems like `python3` will automatically use the current virtual environment.