### PR TITLE
fix(tests): do not attempt to delete tmp file

### DIFF
--- a/differt/src/differt/scene/sionna.py
+++ b/differt/src/differt/scene/sionna.py
@@ -75,7 +75,7 @@ def download_sionna_scenes(
                     yield member
 
         with (
-            tempfile.NamedTemporaryFile(suffix=".tar.gz") as f,
+            tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f,
             tqdm(
                 stream,
                 desc="Downloading Sionna's repository archive...",


### PR DESCRIPTION
Because Windows does not allow for that
