### PR TITLE
fix(docs): avoid self-reference in type annotation

### DIFF
--- a/differt/src/differt/geometry/_paths.py
+++ b/differt/src/differt/geometry/_paths.py
@@ -265,7 +265,7 @@ class Paths(eqx.Module):
     @property
     def masked_vertices(
         self,
-    ) -> Float[Array, "{self.num_valid_paths} {self.path_length} 3"]:
+    ) -> Float[Array, "num_valid_paths path_length 3"]:
         """The array of masked vertices, with batched dimensions flattened into one.
 
         If :attr:`mask` is :data:`None`, then the returned array is simply
@@ -280,7 +280,7 @@ class Paths(eqx.Module):
     @property
     def masked_objects(
         self,
-    ) -> Int[Array, "{self.num_valid_paths} {self.path_length}"]:
+    ) -> Int[Array, "num_valid_paths path_length"]:
         """The array of masked objects, with batched dimensions flattened into one.
 
         Similar to :attr:`masked_vertices`, but for :data:`objects`.

--- a/differt/src/differt/geometry/_triangle_mesh.py
+++ b/differt/src/differt/geometry/_triangle_mesh.py
@@ -220,7 +220,7 @@ class TriangleMesh(eqx.Module):
         return self.num_quads if self.assume_quads else self.num_triangles
 
     @property
-    def triangle_vertices(self) -> Float[Array, "{self.num_triangles} 3 3"]:
+    def triangle_vertices(self) -> Float[Array, "num_triangles 3 3"]:
         """The array of indexed triangle vertices."""
         if self.triangles.size == 0:
             return jnp.empty_like(self.vertices, shape=(0, 3, 3))
@@ -267,7 +267,7 @@ class TriangleMesh(eqx.Module):
         )
 
     @property
-    def normals(self) -> Float[Array, "{self.num_triangles} 3"]:
+    def normals(self) -> Float[Array, "num_triangles 3"]:
         """The triangle normals."""
         vectors = jnp.diff(self.triangle_vertices, axis=1)
         normals = jnp.cross(vectors[:, 0, :], vectors[:, 1, :])
@@ -275,7 +275,7 @@ class TriangleMesh(eqx.Module):
         return normalize(normals)[0]
 
     @property
-    def diffraction_edges(self) -> Int[Array, "{self.num_edges} 3"]:
+    def diffraction_edges(self) -> Int[Array, "num_edges 3"]:
         """The diffraction edges."""
         raise NotImplementedError
 
@@ -350,7 +350,7 @@ class TriangleMesh(eqx.Module):
     @overload
     def set_face_colors(
         self,
-        colors: Float[ArrayLike, "#{self.num_triangles} 3"] | Float[ArrayLike, "3"],
+        colors: Float[ArrayLike, "#num_triangles 3"] | Float[ArrayLike, "3"],
         *,
         key: None = None,
     ) -> Self: ...
@@ -365,7 +365,7 @@ class TriangleMesh(eqx.Module):
 
     def set_face_colors(
         self,
-        colors: Float[ArrayLike, "#{self.num_triangles} 3"]
+        colors: Float[ArrayLike, "#num_triangles 3"]
         | Float[ArrayLike, "3"]
         | None = None,
         *,


### PR DESCRIPTION
Closes #180

Due to some splitting around dots (`.`) when generating docs, including a `{self.attribute}` value in the array annotation will no be displayed as expected. Instead, only the part after `.` is kept, making the documentation look very weird. I could not find any other way to prevent this than removing existing `{self.attribute}` and replacing with `attribute`. This will no longer raise an error if the provided arguments do not match the expected shape (if runtime type checking is used), but hopefully the error will be raised anyway by internal code, e.g., when broadcasting arrays.
