### PR TITLE
chore(ci): undo PGO wheels and drop Python 3.9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,7 +191,7 @@ jobs:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event.inputs.publish-differt-core
     name: Release differt-core
     runs-on: ubuntu-latest
-    needs: [linux, musllinux, windows, macos, sdist]
+    needs: [build-differt-core-linux-wheels, build-differt-core-musllinux-wheels, build-differt-core-windows-wheels, build-differt-core-macos-wheels, build-differt-core-sdist]
     environment: release
     permissions:
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,6 @@ on:
     - '*'
   workflow_dispatch:
     inputs:
-      dry-run:
-        type: boolean
-        description: Dry run
       publish-differt:
         type: boolean
         description: Publish differt
@@ -24,81 +21,24 @@ permissions:
   contents: read
 
 jobs:
-  build-differt-core-wheels:
-    name: Build wheels on ${{ matrix.os }} (${{ matrix.target }} - ${{ matrix.interpreter || 'all' }}${{ matrix.os == 'linux' && format(' - {0}', matrix.manylinux == 'auto' && 'manylinux' || matrix.manylinux) || '' }})
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.event.inputs.publish-differt-core || github.event.inputs.dry-run
+  build-differt-core-linux-wheels:
+    name: Build linux-${{ matrix.platform.target}} wheels for differt-core
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
-      fail-fast: false
       matrix:
-        os: [linux, macos, windows]
-        target: [x86_64, aarch64]
-        manylinux: [auto]
-        include:
-          # manylinux for various platforms, plus x86_64 pypy
-        - os: linux
-          manylinux: auto
-          target: i686
-        - os: linux
-          manylinux: auto
+        platform:
+        - runner: ubuntu-22.04
+          target: x86_64
+        - runner: ubuntu-22.04
+          target: x86
+        - runner: ubuntu-22.04
           target: aarch64
-        - os: linux
-          manylinux: auto
+        - runner: ubuntu-22.04
           target: armv7
-          interpreter: 3.10 3.11 3.12 3.13
-        - os: linux
-          manylinux: auto
-          target: ppc64le
-          interpreter: 3.10 3.11 3.12 3.13
-        - os: linux
-          manylinux: auto
+        - runner: ubuntu-22.04
           target: s390x
-          interpreter: 3.10 3.11 3.12 3.13
-        - os: linux
-          manylinux: auto
-          target: x86_64
-          interpreter: pypy pypy3.10 pypy3.11
-
-          # musllinux
-        - os: linux
-          manylinux: musllinux_1_1
-          target: x86_64
-        - os: linux
-          manylinux: musllinux_1_1
-          target: aarch64
-        - os: linux
-          manylinux: musllinux_1_1
-          target: armv7
-
-          # macos;
-          # all versions x86_64
-          # arm pypy and older pythons which can't be run on the arm hardware for PGO
-        - os: macos
-          target: x86_64
-        - os: macos
-          target: aarch64
-          interpreter: pypy3.10 pypy3.11
-
-          # windows;
-          # x86_64 pypy builds are not PGO optimized
-          # i686 not supported by pypy
-          # aarch64 only 3.11 and up, also not PGO optimized
-        - os: windows
-          target: x86_64
-          interpreter: pypy3.10 pypy3.11
-        - os: windows
-          target: i686
-          python-architecture: x86
-          interpreter: 3.10 3.11 3.12 3.13
-        - os: windows
-          target: aarch64
-          interpreter: 3.11 3.12 3.13
-
-        exclude:
-          # See above; disabled for now.
-        - os: windows
-          target: aarch64
-
-    runs-on: ${{ (matrix.os == 'linux' && 'ubuntu') || matrix.os }}-latest
+        - runner: ubuntu-22.04
+          target: ppc64le
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -106,86 +46,125 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
-        architecture: ${{ matrix.python-architecture || 'x64' }}
+        python-version: 3.x
 
     - name: Build wheels
       uses: PyO3/maturin-action@v1
       with:
-        args: --release --out dist --interpreter ${{ matrix.interpreter || '3.10 3.11 3.12 3.13 pypy3.10 pypy3.11' }}
-        docker-options: -e CI
-        manylinux: ${{ matrix.manylinux }}
-        rust-toolchain: stable
-        target: ${{ matrix.target }}
+        target: ${{ matrix.platform.target }}
+        args: --release --out dist --find-interpreter
+        sccache: 'true'
+        manylinux: auto
         working-directory: differt-core
-
-    - name: List dist directory
-      run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} differt-core/dist/
-
-    - name: Install Twine and check long description
-      run: |
-        pip install -U twine
-        twine check --strict differt-core/dist/*
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: differt-core-wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.interpreter || 'all' }}-${{ matrix.manylinux }}
+        name: differt-core-wheels-linux-${{ matrix.platform.target }}
         path: differt-core/dist
 
-  build-differt-core-pgo-wheels:
-    name: Build PGO wheels on ${{ matrix.os }} (${{ matrix.interpreter }})
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.event.inputs.publish-differt-core || github.event.inputs.dry-run
+  build-differt-core-musllinux-wheels:
+    name: Build musl-${{ matrix.platform.target}} wheels for differt-core
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
-      fail-fast: false
       matrix:
-        os: [linux, macos]  # TODO: put back Windows
-        interpreter: ['3.10', '3.11', '3.12', '3.13']  # TODO: put back 3.13t
-        include:
-          # standard runners with override for macos arm
-        - os: linux
-          runs-on: ubuntu-latest
-        - os: windows
-          ls: dir
-          runs-on: windows-latest
-        - os: macos
-          runs-on: macos-latest
-        # exclude:  # jaxlib wheels not available
-        # - os: windows
-        #   interpreter: 3.13t
-        # - os: macos
-        #   interpreter: 3.13t
-
-    runs-on: ${{ matrix.runs-on }}
+        platform:
+        - runner: ubuntu-22.04
+          target: x86_64
+        - runner: ubuntu-22.04
+          target: x86
+        - runner: ubuntu-22.04
+          target: aarch64
+        - runner: ubuntu-22.04
+          target: armv7
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+    - name: Install Python
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.interpreter }}
+        python-version: 3.x
 
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      id: rust-toolchain
+    - name: Build wheels
+      uses: PyO3/maturin-action@v1
       with:
-        components: llvm-tools
-
-    - name: Build PGO wheel
-      id: pgo-wheel
-      uses: ./.github/actions/build-pgo-wheel
-      with:
-        interpreter: ${{ matrix.interpreter }}
-        rust-toolchain: ${{ steps.rust-toolchain.outputs.name }}
-
-    - name: List dist directory
-      run: ${{ matrix.ls || 'ls -lh' }} differt-core/dist/
+        target: ${{ matrix.platform.target }}
+        args: --release --out dist --find-interpreter
+        sccache: 'true'
+        manylinux: musllinux_1_2
+        working-directory: differt-core
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: differt-core-wheels-${{ matrix.os }}-${{ matrix.interpreter }}
+        name: differt-core-wheels-musllinux-${{ matrix.platform.target }}
+        path: differt-core/dist
+
+  build-differt-core-windows-wheels:
+    name: Build windows-${{ matrix.platform.target}} wheels for differt-core
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+        - runner: windows-latest
+          target: x64
+        - runner: windows-latest
+          target: x86
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+
+    - name: Build wheels
+      uses: PyO3/maturin-action@v1
+      with:
+        target: ${{ matrix.platform.target }}
+        args: --release --out dist --find-interpreter
+        sccache: 'true'
+        working-directory: differt-core
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: differt-core-wheels-windows-${{ matrix.platform.target }}
+        path: differt-core/dist
+
+  build-differt-core-macos-wheels:
+    name: Build macos-${{ matrix.platform.target}} wheels for differt-core
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+        - runner: macos-13
+          target: x86_64
+        - runner: macos-14
+          target: aarch64
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+
+    - name: Build wheels
+      uses: PyO3/maturin-action@v1
+      with:
+        target: ${{ matrix.platform.target }}
+        args: --release --out dist --find-interpreter
+        sccache: 'true'
+        working-directory: differt-core
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: differt-core-wheels-macos-${{ matrix.platform.target }}
         path: differt-core/dist
 
   build-differt-core-sdist:
@@ -209,10 +188,10 @@ jobs:
         path: differt-core/dist
 
   release-differt-core:
-    if: success() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish-differt-core)
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event.inputs.publish-differt-core
     name: Release differt-core
     runs-on: ubuntu-latest
-    needs: [build-differt-core-sdist, build-differt-core-wheels, build-differt-core-pgo-wheels]
+    needs: [linux, musllinux, windows, macos, sdist]
     environment: release
     permissions:
       id-token: write
@@ -232,6 +211,7 @@ jobs:
       uses: actions/attest-build-provenance@v2
       with:
         subject-path: differt-core/dist/differt-core-wheels-*
+
     - name: Publish to PyPI
       uses: PyO3/maturin-action@v1
       with:
@@ -240,7 +220,7 @@ jobs:
         working-directory: differt-core
 
   build-differt:
-    name: Build differt wheels and sdist
+    name: Build DiffeRT
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -268,8 +248,8 @@ jobs:
         path: differt/dist/differt-*.whl
 
   release-differt:
-    if: success() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish-differt)
-    name: Release differt
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event.inputs.publish-differt
+    name: Release DiffeRT
     runs-on: ubuntu-latest
     needs: [build-differt]
     environment: release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,18 +155,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -399,14 +399,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
- "windows-targets",
 ]
 
 [[package]]
@@ -417,9 +417,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -439,15 +439,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -456,15 +456,15 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linked-hash-map"
@@ -510,9 +510,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "log"
@@ -653,15 +653,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "paste"
@@ -879,12 +879,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rawpointer"
@@ -993,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
  "bitflags",
  "errno",
@@ -1006,15 +1012,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
@@ -1036,27 +1042,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1120,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1137,11 +1143,10 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom",
  "once_cell",
@@ -1182,15 +1187,15 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unindent"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "version_check"
@@ -1210,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -1379,9 +1384,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]

--- a/differt-core/Cargo.toml
+++ b/differt-core/Cargo.toml
@@ -10,7 +10,7 @@ ndarray = {version = "0.16", features = ["rayon"]}
 numpy = "0.24"
 obj-rs = "0.7.1"
 ply-rs = "0.1.3"
-pyo3 = {version = "0.24", features = ["indexmap", "generate-import-lib"]}
+pyo3 = {version = "0.24", features = ["abi3-py310", "indexmap", "generate-import-lib"]}
 pyo3-log = {version = "0.13", git = "https://github.com/vorner/pyo3-log.git", rev = "refs/pull/62/head"}
 quick-xml = {version = "0.31.0", features = ["serialize"]}
 serde = {version = "1.0.197", features = ["derive"]}

--- a/differt-core/pyproject.toml
+++ b/differt-core/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -25,7 +24,7 @@ description = "Core backend of DifffeRT implemented in Rust"
 dynamic = ["license", "readme", "version"]
 keywords = ["ray tracing", "differentiable", "propagation", "radio", "jax"]
 name = "differt-core"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 [tool.maturin]
 bindings = "pyo3"


### PR DESCRIPTION
Undo PGO builds because they are too complex (fail for weird reasons, take very long time to complete, and require tests deps to be installed). ABI wheels are now generated again, until we find a better solution for PGO wheels.
