### PR TITLE
fix(lib): avoid NaNs in the gradient of the Image method

### DIFF
--- a/differt/src/differt/em/_fresnel.py
+++ b/differt/src/differt/em/_fresnel.py
@@ -128,7 +128,7 @@ def fresnel_coefficients(
 
             >>> from differt.em import fresnel_coefficients
             >>>
-            >>> n = 1.5  # Air to glass
+            >>> n = 1.5 + 0j  # Air to glass
             >>> theta = jnp.linspace(0, jnp.pi / 2)
             >>> cos_theta = jnp.cos(theta)
             >>> (r_s, r_p), (t_s, t_p) = fresnel_coefficients(n, cos_theta)
@@ -155,7 +155,7 @@ def fresnel_coefficients(
 
             >>> from differt.em import fresnel_coefficients
             >>>
-            >>> n = 1/ 1.5  #  Glass to air
+            >>> n = 1 / 1.5 + 0j  #  Glass to air
             >>> theta = jnp.linspace(0, jnp.pi / 2, 300)
             >>> cos_theta = jnp.cos(theta)
             >>> (r_s, r_p), (t_s, t_p) = fresnel_coefficients(n, cos_theta)

--- a/differt/src/differt/geometry/_utils.py
+++ b/differt/src/differt/geometry/_utils.py
@@ -800,6 +800,7 @@ def cartesian_to_spherical(
     """
     xyz = jnp.asarray(xyz)
     r = jnp.linalg.norm(xyz, axis=-1)
+    r = jnp.where(r == 0.0, jnp.ones_like(r), r)
     p = jnp.arccos(xyz[..., -1] / r)
     a = jnp.arctan2(xyz[..., 1], xyz[..., 0])
 

--- a/differt/src/differt/geometry/_utils.py
+++ b/differt/src/differt/geometry/_utils.py
@@ -800,7 +800,7 @@ def cartesian_to_spherical(
     """
     xyz = jnp.asarray(xyz)
     r = jnp.linalg.norm(xyz, axis=-1)
-    r = jnp.where(r == 0.0, jnp.ones_like(r), r)
+    r: Array = jnp.where(r == 0.0, jnp.ones_like(r), r)
     p = jnp.arccos(xyz[..., -1] / r)
     a = jnp.arctan2(xyz[..., 1], xyz[..., 0])
 

--- a/differt/src/differt/rt/_image_method.py
+++ b/differt/src/differt/rt/_image_method.py
@@ -119,8 +119,13 @@ def intersection_of_rays_with_planes(
     # [*batch 1]
     vn = dot(v, plane_normals, keepdims=True)
 
-    t = vn / jnp.where(vn == 0.0, 1.0, un)
-    return ray_origins + ray_directions * jnp.where(u == 0.0, 1.0, t)
+    parallel = un == 0.0
+    un = jnp.where(parallel, 1.0, un)
+
+    t = jnp.where(vn == 0.0, vn, jnp.where(parallel, jnp.inf, vn / un))
+    return ray_origins + ray_directions * jnp.where(
+        (u == 0.0).all(axis=-1, keepdims=True), 1.0, t
+    )
 
 
 @jax.jit

--- a/differt/src/differt/rt/_utils.py
+++ b/differt/src/differt/rt/_utils.py
@@ -532,7 +532,7 @@ def first_triangles_hit_by_rays(
             triangle_vertices,
             **kwargs,
         )
-        t = jnp.where(hit, t, jnp.inf)
+        t = jnp.where(hit, t, jnp.full_like(t, jnp.inf))
         indices = jnp.where(t < t_hit, index, indices)
         t_hit = jnp.minimum(t, t_hit)
         return (indices, t_hit, index + 1), None

--- a/differt/src/differt/utils.py
+++ b/differt/src/differt/utils.py
@@ -327,4 +327,8 @@ def safe_divide(
     # TODO: add :python: rst role for x / y in docs
     num = jnp.asarray(num)
     den = jnp.asarray(den)
-    return jnp.where(den == 0, 0, num / den)
+    shape = jnp.broadcast_shapes(num.shape, den.shape)
+    dtype = jnp.result_type(num, den)
+    zero_div = den == 0.0
+    den = jnp.where(zero_div, jnp.ones_like(den), den)
+    return jnp.where(zero_div, jnp.zeros(shape, dtype=dtype), num / den)

--- a/differt/tests/em/test_fresnel.py
+++ b/differt/tests/em/test_fresnel.py
@@ -36,7 +36,7 @@ def test_fresnel_coefficients(key: PRNGKeyArray) -> None:
     n_1 = jax.random.uniform(key_n_1, (100,), minval=0.01, maxval=2.0)
     n_2 = jax.random.uniform(key_n_2, (100,), minval=0.01, maxval=2.0)
 
-    n_r = n_2 / n_1
+    n_r = (n_2 / n_1).astype(jnp.complex64)
     theta_i = jnp.linspace(0, jnp.pi / 2)
     cos_theta_i = jnp.cos(theta_i)
     n_r = n_r[..., None]

--- a/differt/tests/rt/test_image_method.py
+++ b/differt/tests/rt/test_image_method.py
@@ -2,11 +2,12 @@ from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
 
 import chex
+import jax
 import jax.numpy as jnp
 import pytest
 from jaxtyping import Array, PRNGKeyArray
 
-from differt.geometry._utils import normalize
+from differt.geometry import normalize
 from differt.rt._image_method import (
     consecutive_vertices_are_on_same_side_of_mirrors,
     image_method,
@@ -103,6 +104,34 @@ def test_intersection_of_rays_with_planes() -> None:
         plane_normals,
     )
     chex.assert_trees_all_close(got, expected)
+
+
+def test_intersection_of_rays_with_planes_parallel() -> None:
+    ray_origins = jnp.array(
+        [[-1.0, +1.0, +0.0], [-2.0, +1.0, +0.0], [-3.0, +1.0, +0.0]],
+    )
+    ray_ends = jnp.broadcast_to(jnp.array([[2.0, -1.0, 0.0]]), ray_origins.shape)
+    ray_directions = ray_ends - ray_origins
+    plane_vertices = jnp.array([[0.0, 0.0, 0.0]])
+    plane_normals = jnp.array([[0.0, 0.0, 1.0]])
+    got = intersection_of_rays_with_planes(
+        ray_origins,
+        ray_directions,
+        plane_vertices,
+        plane_normals,
+    )
+    expected = jnp.full_like(got, jnp.inf)
+    chex.assert_trees_all_close(got, expected)
+
+    # Check that we have non-NaNs gradient
+    grads = jax.grad(intersection_of_rays_with_planes)(
+        ray_origins,
+        ray_directions,
+        plane_vertices,
+        plane_normals,
+    )
+
+    assert not jnp.isnan(grads).any()
 
 
 @pytest.mark.parametrize(

--- a/differt/tests/rt/test_image_method.py
+++ b/differt/tests/rt/test_image_method.py
@@ -112,7 +112,7 @@ def test_intersection_of_rays_with_planes_parallel() -> None:
     )
     ray_ends = jnp.broadcast_to(jnp.array([[2.0, -1.0, 0.0]]), ray_origins.shape)
     ray_directions = ray_ends - ray_origins
-    plane_vertices = jnp.array([[0.0, 0.0, 0.0]])
+    plane_vertices = jnp.array([[0.0, 0.0, -1.0]])
     plane_normals = jnp.array([[0.0, 0.0, 1.0]])
     got = intersection_of_rays_with_planes(
         ray_origins,
@@ -124,7 +124,7 @@ def test_intersection_of_rays_with_planes_parallel() -> None:
     chex.assert_trees_all_close(got, expected)
 
     # Check that we have non-NaNs gradient
-    grads = jax.grad(intersection_of_rays_with_planes)(
+    grads = jax.grad(lambda *args: intersection_of_rays_with_planes(*args).sum())(
         ray_origins,
         ray_directions,
         plane_vertices,
@@ -132,6 +132,18 @@ def test_intersection_of_rays_with_planes_parallel() -> None:
     )
 
     assert not jnp.isnan(grads).any()
+
+    # Ray origins are on the plane
+
+    plane_vertices = jnp.array([[0.0, 0.0, 0.0]])
+    got = intersection_of_rays_with_planes(
+        ray_origins,
+        ray_directions,
+        plane_vertices,
+        plane_normals,
+    )
+    expected = ray_origins
+    chex.assert_trees_all_close(got, expected)
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ addopts = [
 ]
 doctest_optionflags = ["NORMALIZE_WHITESPACE"]
 env = [
+  "JAX_DEBUG_NANS=True",
   "JAX_PLATFORM_NAME=cpu",
 ]
 filterwarnings = [


### PR DESCRIPTION
While we avoid returning the result of division by zero, it is still evaluated (because `jnp.where` executes both branches), resulting in a NaN output in the gradient of the intersection with planes tests, when rays are parallel to the planes. We want to avoid this, as it can cause issues in upstream gradient descends.
