### PR TITLE
chore(lib): move `jnp.abs(cos_theta)` inside `fresnel_coefficients`

### DIFF
--- a/differt/src/differt/em/_fresnel.py
+++ b/differt/src/differt/em/_fresnel.py
@@ -180,7 +180,8 @@ def fresnel_coefficients(
             >>> plt.legend()  # doctest: +SKIP
             >>> plt.tight_layout()  # doctest: +SKIP
     """
-    cos_theta_i = jnp.asarray(cos_theta_i)
+    # Fresnel coefficients are only defined for theta in [-pi/2, pi/2]
+    cos_theta_i = jnp.abs(jnp.asarray(cos_theta_i))
     n_r_squared = jax.lax.integer_pow(n_r, 2)
     cos_theta_i_squared = jax.lax.integer_pow(cos_theta_i, 2)
     n_r_squared_cos_theta_i = n_r_squared * cos_theta_i

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -36,6 +36,21 @@ so that changes are taken into accounts:
 uv sync --reinstall-package differt-core
 ```
 
+Alternatively, you can install an import hook that will recompile the
+{mod}`differt_core` package each time it is imported:
+
+```bash
+just hook-install
+```
+
+While recompiling a package that hasn't changed is relatively fast,
+it may be better to disable the import hook when it is not needed.
+You can do so by uninstalling it:
+
+```bash
+just hook-uninstall
+```
+
 ### Documentation
 
 To generate the documentation, please run the following (from the root folder):

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -71,7 +71,7 @@ To run build this package locally, you need:
 - and [uv>= 0.4.25](https://docs.astral.sh/uv/) to manage this project.
 
 This project contains `justfile`s with recipes[^2] for most common
-use cases, so feel free to use them instead of the commands listed below/
+use cases, so feel free to use them instead of the commands listed below.
 
 [^2]: `just` is as alternative tool to Make, that provides more modern
   user experience. Enter `just` to list all available recipes.

--- a/docs/source/notebooks/coherence.ipynb
+++ b/docs/source/notebooks/coherence.ipynb
@@ -226,7 +226,7 @@
     "                    k_i, k_r, obj_normals\n",
     "                )\n",
     "                # [*batch num_path_candidates order 1]\n",
-    "                cos_theta = jnp.abs(dot(obj_normals, -k_i, keepdims=True))\n",
+    "                cos_theta = dot(obj_normals, -k_i, keepdims=True)\n",
     "                # [*batch num_path_candidates order 1]\n",
     "                r_s, r_p = reflection_coefficients(\n",
     "                    obj_n_r[..., None], cos_theta\n",


### PR DESCRIPTION
As Fresnel coefficient are not defined for angles outside `[-pi/2, pi/2]`, the absolute value of the cosine is taken inside the function, to improve clarity in notebooks.
