### PR TITLE
chore(lib): avoid drawing markers with Plotly's `draw_paths` impl.

### DIFF
--- a/differt/src/differt/plotting/_core.py
+++ b/differt/src/differt/plotting/_core.py
@@ -187,7 +187,6 @@ def draw_paths(
             >>> fig = draw_paths(
             ...     paths,
             ...     backend="plotly",
-            ...     marker=dict(size=0, color="red"),
             ...     line=dict(color="black", width=3),
             ... )
             >>> fig  # doctest: +SKIP
@@ -239,6 +238,8 @@ def _(
     **kwargs: Any,
 ) -> Figure:
     fig = process_plotly_kwargs(kwargs)
+
+    kwargs.setdefault("mode", "lines")
 
     paths = np.asarray(paths)
     paths = paths.reshape(-1, *paths.shape[-2:])

--- a/differt/src/differt/rt/_image_method.py
+++ b/differt/src/differt/rt/_image_method.py
@@ -258,7 +258,12 @@ def image_method(
             ...         ),
             ...         axis=0,
             ...     )
-            ...     draw_paths(full_path, marker={"color": "green"}, name="Final path")
+            ...     draw_paths(
+            ...         full_path,
+            ...         mode="lines+markers",
+            ...         marker={"color": "green"},
+            ...         name="Final path",
+            ...     )
             ...     markers = jnp.vstack((from_vertex, to_vertex))
             ...     draw_markers(
             ...         markers,

--- a/docs/source/notebooks/advanced_path_tracing.ipynb
+++ b/docs/source/notebooks/advanced_path_tracing.ipynb
@@ -258,10 +258,6 @@
     "    dplt.draw_paths(\n",
     "        full_path,\n",
     "        figure=fig,\n",
-    "        marker={\n",
-    "            \"size\": 0,\n",
-    "            \"color\": \"black\",\n",
-    "        },\n",
     "        line={\"color\": color[len(path_candidate)], \"width\": 3},\n",
     "        name=f\"Order {len(path_candidate)}\",\n",
     "    )\n",
@@ -393,10 +389,6 @@
     "    dplt.draw_paths(\n",
     "        full_paths,\n",
     "        figure=fig,\n",
-    "        marker={\n",
-    "            \"size\": 0,\n",
-    "            \"color\": \"black\",\n",
-    "        },\n",
     "        line={\"color\": color[order], \"width\": 3},\n",
     "        name=f\"Order {order}\",\n",
     "    )\n",
@@ -925,7 +917,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/diffraction.ipynb
+++ b/docs/source/notebooks/diffraction.ipynb
@@ -67,7 +67,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/ray_tracing_at_city_scale.ipynb
+++ b/docs/source/notebooks/ray_tracing_at_city_scale.ipynb
@@ -118,7 +118,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previously, vertex markers were drawn with Plotly's implementation of `draw_paths` in the case were the number of vertices was small (< 20, according to their docs). This default behavior does not make much sense with respect to Matplotlib's and VisPy's implementation, and vertex markers will usually overlap with other markers such as the ones of TX/RX nodes. The default behavior is now to only draw lines, i.e., with `mode="lines"`.
