### PR TITLE
feat(lib): allow to mask duplicates with `confidence` matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,17 @@ with one *slight* but **important** difference:
 
 ## [Unreleased](https://github.com/jeertmans/DiffeRT/compare/v0.1.0...HEAD)
 
+### Added
+
+- Added support for `confidence` attribute in `Paths.mask_duplicate_objects` (by <gh-user:jeertmans>, in <gh-pr:272>).
+
 ### Chore
 
 - Documented how to build from sources without Rust, i.e., without building `differt_core` (by <gh-user:jeertmans>, in <gh-pr:269>).
+
+### Fixed
+
+- Fixed potential `IndexError` in `TriangleScene.num_{transmitters,receivers}` when the TX/RX arrays have incorrect shape (by <gh-user:jeertmans>, in <gh-pr:272>).
 
 <!-- start changelog -->
 

--- a/differt/src/differt/scene/_triangle_scene.py
+++ b/differt/src/differt/scene/_triangle_scene.py
@@ -555,12 +555,12 @@ class TriangleScene(eqx.Module):
     @property
     def num_transmitters(self) -> int:
         """The number of transmitters."""
-        return self.transmitters[..., 0].size
+        return self.transmitters.size // 3
 
     @property
     def num_receivers(self) -> int:
         """The number of receivers."""
-        return self.receivers[..., 0].size
+        return self.receivers.size // 3
 
     def set_assume_quads(self, flag: bool = True) -> Self:
         """

--- a/differt/tests/geometry/test_paths.py
+++ b/differt/tests/geometry/test_paths.py
@@ -137,17 +137,29 @@ class TestPaths:
         paths = scene.compute_paths(path_candidates=path_candidates)
 
         assert paths.mask is not None
+        mask = paths.mask
         paths = eqx.tree_at(lambda p: p.mask, paths, jnp.ones_like(paths.mask))
 
         got = paths.mask_duplicate_objects()
 
-        chex.assert_trees_all_equal(got.mask.sum(axis=-1), 3)
+        chex.assert_trees_all_equal(got.num_valid_paths, 3)
 
         paths = eqx.tree_at(lambda p: p.mask, paths, None)
 
         got = paths.mask_duplicate_objects()
 
-        chex.assert_trees_all_equal(got.mask.sum(axis=-1), 3)
+        chex.assert_trees_all_equal(got.num_valid_paths, 3)
+
+        paths = eqx.tree_at(
+            lambda p: p.confidence,
+            paths,
+            jnp.ones_like(mask, dtype=float),
+            is_leaf=lambda x: x is None,
+        )
+
+        got = paths.mask_duplicate_objects()
+
+        chex.assert_trees_all_equal(got.num_valid_paths, 3)
 
         with pytest.raises(
             ValueError,
@@ -159,23 +171,26 @@ class TestPaths:
 
         scene = scene.with_transmitters_grid(2, 1).with_receivers_grid(4, 3)
 
+        batch_size = scene.num_transmitters * scene.num_receivers
+
         paths = scene.compute_paths(path_candidates=path_candidates)
 
         assert paths.mask is not None
+        mask = paths.mask
         chex.assert_shape(paths.mask, (1, 2, 3, 4, path_candidates.shape[0]))
         paths = eqx.tree_at(lambda p: p.mask, paths, jnp.ones_like(paths.mask))
 
         got = paths.mask_duplicate_objects()
 
         chex.assert_shape(got.mask, (1, 2, 3, 4, path_candidates.shape[0]))
-        chex.assert_trees_all_equal(got.mask.sum(axis=-1), 3)
+        chex.assert_trees_all_equal(got.num_valid_paths, 3 * batch_size)
 
         paths = eqx.tree_at(lambda p: p.mask, paths, None)
 
         got = paths.mask_duplicate_objects()
 
         chex.assert_shape(got.mask, (1, 2, 3, 4, path_candidates.shape[0]))
-        chex.assert_trees_all_equal(got.mask.sum(axis=-1), 3)
+        chex.assert_trees_all_equal(got.num_valid_paths, 3 * batch_size)
 
         paths = eqx.tree_at(
             lambda p: (p.vertices, p.objects),
@@ -186,7 +201,18 @@ class TestPaths:
         got = paths.mask_duplicate_objects(axis=0)
 
         chex.assert_shape(got.mask, (path_candidates.shape[0], 2, 3, 4, 1))
-        chex.assert_trees_all_equal(got.mask.sum(axis=0), 3)
+        chex.assert_trees_all_equal(got.num_valid_paths, 3 * batch_size)
+
+        paths = eqx.tree_at(
+            lambda p: p.confidence,
+            paths,
+            jnp.ones((path_candidates.shape[0], 2, 3, 4, 1), dtype=float),
+            is_leaf=lambda x: x is None,
+        )
+
+        got = paths.mask_duplicate_objects(axis=0)
+
+        chex.assert_trees_all_equal(got.num_valid_paths, 3 * batch_size)
 
     @pytest.mark.parametrize("path_length", [3, 5])
     @pytest.mark.parametrize("batch", [(), (1,), (1, 2, 3, 4)])


### PR DESCRIPTION
Before, the `mask` attribute would be updated, regardless of the presence of a `confidence` attribute instead. Now, the updated attribute depends on the presence of either `mask` or `confidence`.
