### PR TITLE
feat(lib): deprecate `minimize` in favor of problem-specific solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,14 @@ with one *slight* but **important** difference:
 
 ## [Unreleased](https://github.com/jeertmans/DiffeRT/compare/v0.1.1...HEAD)
 
+### Changed
+
+- Deprecated {func}`minimize<differt.utils.minimize>` in favor of specialized implementations, see <gh-pr:283> for motivation and migration information (by <gh-user:jeertmans>, in <gh-pr:283>).
+- Changed the default `optimizer` used by {func}`fermat_path_on_linear_objects<differt.rt.fermat_path_on_linear_objects>` to be {func}`optax.lbfgs` (by <gh-user:jeertmans>, in <gh-pr:272>).
+
 ### Fixed
 
-- Fixed `ValueError` raised when using `parallel` mode with `jax>=0.6` by disabling it (see <gh-issue:280>). This is a *soft* **breaking change** as it will raise a warning (by <gh-user:jeertmans>, in <gh-pr:281>). Using JAX v0.6 (and above) is now allowed again.
+- Fixed {class}`ValueError` raised when using `parallel` mode in {meth}`TriangleScene.compute_paths<differt.scene.TriangleScene.compute_paths>` with `jax>=0.6` by disabling it (see <gh-issue:280>). This is a *soft* **breaking change** as it will raise a warning (by <gh-user:jeertmans>, in <gh-pr:281>). Using JAX v0.6 (and above) is now allowed again.
 
 <!-- start changelog -->
 
@@ -30,22 +35,22 @@ with one *slight* but **important** difference:
 
 ### Added
 
-- Added support for `confidence` attribute in `Paths.mask_duplicate_objects` (by <gh-user:jeertmans>, in <gh-pr:272>).
-- Added the `Paths.shape` class attribute (by <gh-user:jeertmans>, in <gh-pr:267>).
+- Added support for {attr}`confidence<differt.geometry.Paths.confidence>` attribute in {attr}`Paths.mask_duplicate_objects<differt.geometry.Paths.mask_duplicate_objects>` (by <gh-user:jeertmans>, in <gh-pr:272>).
+- Added the {attr}`Paths.shape<differt.geometry.Paths.shape>` class attribute (by <gh-user:jeertmans>, in <gh-pr:267>).
   The following equality should always hold: `paths.reshape(*batch).shape = batch`.
-- Added the `differt.plugins` package and `differt.plugins.deepmimo` module (by <gh-user:jeertmans>, in <gh-pr:267>).
+- Added the {mod}`differt.plugins` package and {mod}`differt.plugins.deepmimo` module (by <gh-user:jeertmans>, in <gh-pr:267>).
 - Added export utility to the [DeepMIMO](https://github.com/DeepMIMO) format (by <gh-user:jeertmans>, in <gh-pr:267>).
-- Added `from_mitsuba` and `from_sionna` methods to the `TriangleScene` class (by <gh-user:jeertmans>, in <gh-pr:267>).
+- Added {meth}`from_mitsuba<differt.scene.TriangleScene.from_mitsuba>` and {meth}`from_sionna<differt.scene.TriangleScene.from_sionna>` methods to the {class}`TriangleScene<differt.scene.TriangleScene>` class (by <gh-user:jeertmans>, in <gh-pr:267>).
 
 ### Chore
 
-- Documented how to build from sources without Rust, i.e., without building `differt_core` (by <gh-user:jeertmans>, in <gh-pr:269>).
+- Documented how to build from sources without Rust, i.e., without building {mod}`differt_core` (by <gh-user:jeertmans>, in <gh-pr:269>).
 - Fixed link issues (`jnp.{minimum,maximum}` and false-positive on DOI check) (by <gh-user:jeertmans>, in <gh-pr:274>).
 
 ### Fixed
 
-- Fixed potential `IndexError` in `TriangleScene.num_{transmitters,receivers}` when the TX/RX arrays have incorrect shape (by <gh-user:jeertmans>, in <gh-pr:272>).
-- Fixed potential `IndexError` in `Paths.num_valid_paths` when the `objects` array has its last axis being of zero size (by <gh-user:jeertmans>, in <gh-pr:273>).
+- Fixed potential {class}`IndexError` in {attr}`TriangleScene.num_{transmitters,receivers}<differt.scene.TriangleScene.num_transmitters>` when the TX/RX arrays have incorrect shape (by <gh-user:jeertmans>, in <gh-pr:272>).
+- Fixed potential {class}`IndexError` in {attr}`Paths.num_valid_paths<differt.geometry.Paths.num_valid_paths>` when the {attr}`objects<differt.geometry.Paths.objects>` array has its last axis being of zero size (by <gh-user:jeertmans>, in <gh-pr:273>).
 
 ## [0.1.0](https://github.com/jeertmans/DiffeRT/tree/v0.1.0)
 

--- a/differt/src/differt/rt/_image_method.py
+++ b/differt/src/differt/rt/_image_method.py
@@ -290,6 +290,14 @@ def image_method(
         mirror_normals.shape[1:],
     )
 
+    if mirror_vertices.shape[0] == 0:
+        # If there are no mirrors, return empty array.
+        *batch, _ = batch_and_3
+        dtype = jnp.result_type(
+            from_vertices, to_vertices, mirror_vertices, mirror_normals
+        )
+        return jnp.empty((*batch, 0, 3), dtype=dtype)
+
     from_vertices = jnp.broadcast_to(from_vertices, batch_and_3)
     to_vertices = jnp.broadcast_to(to_vertices, batch_and_3)
 
@@ -419,6 +427,11 @@ def consecutive_vertices_are_on_same_side_of_mirrors(
     chex.assert_axis_dimension(
         vertices, -2, mirror_vertices.shape[-2] + 2, exception_type=TypeError
     )
+
+    if mirror_vertices.shape[-2] == 0:
+        # If there are no mirrors, return empty array.
+        dtype = bool if smoothing_factor is None else float
+        return jnp.empty(mirror_vertices.shape[:-1], dtype=dtype)
 
     # dot_{prev,next} = <(v_{prev,next} - mirror_v), mirror_n>
 

--- a/differt/src/differt/utils.py
+++ b/differt/src/differt/utils.py
@@ -1,5 +1,6 @@
 """General purpose utilities."""
 
+import warnings
 from collections.abc import Callable
 from functools import partial
 from typing import (
@@ -147,7 +148,14 @@ P = ParamSpec("P")
 
 
 class OptimizeResult(NamedTuple):
-    """A class to hold the result of an optimization, akin to :class:`scipy.optimize.OptimizeResult`."""
+    """
+    A class to hold the result of an optimization, akin to :class:`scipy.optimize.OptimizeResult`.
+
+    .. deprecated:: 0.1.2
+        This class is deprecated and will be removed in the v0.2.0 release.
+        See `#283 <https://github.com/jeertmans/DiffeRT/issues/283>`_ for motivation
+        and alternatives.
+    """
 
     x: Inexact[Array, "*batch n"]
     """The solution of the optimization."""
@@ -165,6 +173,11 @@ def minimize(
 ) -> OptimizeResult:
     """
     Minimize a scalar function of one or more variables.
+
+    .. deprecated:: 0.1.2
+        This function is deprecated and will be removed in the v0.2.0 release.
+        See `#283 <https://github.com/jeertmans/DiffeRT/issues/283>`_ for motivation
+        and alternatives.
 
     The minimization is achieved by computing the
     gradient of the objective function, and performing
@@ -201,81 +214,13 @@ def minimize(
 
     Returns:
         The optimization result.
-
-    Examples:
-        The following example shows how to minimize a basic function.
-
-        >>> from differt.utils import minimize
-        >>> import chex
-        >>>
-        >>> def f(x, offset=1.0):
-        ...     x = x - offset
-        ...     return jnp.dot(x, x)
-        >>>
-        >>> x, y = minimize(f, jnp.zeros(10))
-        >>> chex.assert_trees_all_close(x, jnp.ones(10), rtol=1e-2)
-        >>> chex.assert_trees_all_close(y, 0.0, atol=1e-4)
-        >>>
-        >>> # It is also possible to pass positional arguments
-        >>> x, y = minimize(f, jnp.zeros(10), args=(2.0,))
-        >>> chex.assert_trees_all_close(x, 2.0 * jnp.ones(10), rtol=1e-2)
-        >>> chex.assert_trees_all_close(y, 0.0, atol=1e-3)
-        >>>
-        >>> # You can also change the optimizer and the number of steps
-        >>> import optax
-        >>> optimizer = optax.noisy_sgd(learning_rate=0.003, key=jax.random.key(1234))
-        >>> x, y = minimize(
-        ...     f, jnp.zeros(5), args=(4.0,), steps=10000, optimizer=optimizer
-        ... )
-        >>> chex.assert_trees_all_close(x, 4.0 * jnp.ones(5), rtol=1e-2)
-        >>> chex.assert_trees_all_close(y, 0.0, atol=1e-3)
-
-        This example shows how you can minimize on a batch of arrays.
-
-        >>> from differt.utils import minimize
-        >>> import chex
-        >>>
-        >>> batch = (1, 2, 3)
-        >>> n = 10
-        >>> key = jax.random.key(1234)
-        >>> offset = jax.random.uniform(key, (*batch, n))
-        >>>
-        >>> def f(x, offset, scale=2.0):
-        ...     x = scale * x - offset
-        ...     return jnp.sum(x * x, axis=-1)
-        >>>
-        >>> x0 = jnp.zeros((*batch, n))
-        >>> x, y = minimize(f, x0, args=(offset,), steps=1000)
-        >>> chex.assert_trees_all_close(x, offset / 2.0, rtol=1e-2)
-        >>> chex.assert_trees_all_close(y, 0.0, atol=1e-4)
-        >>>
-        >>> # By default, arguments are expected to have batch
-        >>> # dimensions like 'x0'. So, if 'x0' has more than one dimension,
-        >>> # 'offset' must be an ndarray with the same shape prefix as 'x0':
-        >>> offset = 10.0
-        >>> x, y = minimize(
-        ...     f, x0, args=(offset,), steps=1000
-        ... )  # doctest: +IGNORE_EXCEPTION_DETAIL
-        Traceback (most recent call last):
-        TypeError: ... Tree leaf '0' is not an ndarray (type=<class 'float'>).
-        >>>
-        >>> # Passing 'offset' as an ndarray instead:
-        >>> x, y = minimize(
-        ...     f, x0, args=(jnp.array(offset),), steps=1000
-        ... )  # doctest: +IGNORE_EXCEPTION_DETAIL
-        Traceback (most recent call last):
-        TypeError: ... Tree leaf '1' has a shape of length 0 (shape=()) which
-        is smaller than the expected prefix of length 3 (prefix=(1, 2, 3)).
-        >>>
-        >>> # For static arguments, use functools.partial
-        >>> from functools import partial
-        >>>
-        >>> fp = partial(f, offset=offset)
-        >>> x, y = minimize(fp, x0, steps=1000)
-        >>> chex.assert_trees_all_close(x, offset * jnp.ones_like(x0) / 2.0, rtol=1e-2)
-        >>> chex.assert_trees_all_close(y, 0.0, atol=1e-2)
     """
-    # TODO: avoid requiring arrays to be already broadcasted (use in_axes?) and improve signature
+    msg = (
+        "This function is deprecated and will be removed in the v0.2.0 release. "
+        "See https://github.com/jeertmans/DiffeRT/issues/283 for motivation and alternatives."
+    )
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+
     x0 = jnp.asarray(x0)
     if x0.ndim > 1 and args:
         chex.assert_tree_has_only_ndarrays(args, exception_type=TypeError)

--- a/differt/tests/test_utils.py
+++ b/differt/tests/test_utils.py
@@ -85,6 +85,8 @@ def test_sorted_array2(array: Array, expected: Array) -> None:
 
 
 def test_minimize() -> None:
+    deprecation_msg = "This function is deprecated and will be removed"
+
     def fun(x: Array, a: Array, b: Array, c: Array) -> Array:
         return (x[..., 0] - a) ** 2.0 + (x[..., 1] - b) ** 2.0 + c
 
@@ -95,7 +97,8 @@ def test_minimize() -> None:
     a, b, c = jnp.meshgrid(a, b, c)
     x0 = jnp.zeros((*a.shape, 2))
 
-    got_x, got_loss = minimize(fun, x0, args=(a, b, c), steps=1000)
+    with pytest.warns(DeprecationWarning, match=deprecation_msg):
+        got_x, got_loss = minimize(fun, x0, args=(a, b, c))
 
     expected_x = jnp.stack((a, b), axis=-1)
 
@@ -104,15 +107,24 @@ def test_minimize() -> None:
     chex.assert_trees_all_close(got_x, expected_x)
     chex.assert_trees_all_close(got_loss, c)
 
-    with pytest.raises(
-        TypeError, match="Assertion assert_tree_has_only_ndarrays failed"
+    with (
+        pytest.raises(
+            TypeError, match="Assertion assert_tree_has_only_ndarrays failed"
+        ),
+        pytest.warns(DeprecationWarning, match=deprecation_msg),
     ):
         _ = minimize(fun, x0, args=(0.0, b, c))
 
-    with pytest.raises(TypeError, match="Assertion assert_tree_shape_prefix failed"):
+    with (
+        pytest.raises(TypeError, match="Assertion assert_tree_shape_prefix failed"),
+        pytest.warns(DeprecationWarning, match=deprecation_msg),
+    ):
         _ = minimize(fun, x0, args=(a[0, ...], b, c))
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+    with (
+        pytest.raises(TypeError, match="missing 1 required positional argument"),
+        pytest.warns(DeprecationWarning, match=deprecation_msg),
+    ):
         _ = minimize(fun, x0, args=(a, b))
 
 


### PR DESCRIPTION
Maintaining `differt.utils.minimize` is relatively complex, especially if we want to allow for arbitrary optimizers, objective functions, and batches.

As we are only using `minimize` once in the codebase (for Fermat path tracing), it makes more sense to deprecate the `minimize` function in favor of a specialized implementation. This reduces the complexity while hopefully allowing better performance.

If you were using `minimize` and don't know how to implement a `minimize` function yourself, feel free to ask for help in the discussions section.
