### PR TITLE
feat(lib): add `TriangleMesh.mask` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ with one *slight* but **important** difference:
 
 ## [Unreleased](https://github.com/jeertmans/DiffeRT/compare/v0.1.2...HEAD)
 
+### Added
+
+- Added {attr}`TriangleMesh.mask<differt.geometry.TriangleMesh.mask>` attribute has been added to allow triangles to be selected using a mask instead of dropping the inactive ones. This is useful for generating multiple sub-meshes of a mesh without changing the memory allocated to each sub-mesh, thus enabling efficient stacking (by <gh-user:jeertmans>, in <gh-pr:287>).
+- Added a new `by_masking: bool = False` keyword-only parameter to {meth}`TriangleMesh.sample<differt.geometry.TriangleMesh.sample>` to allow sampling sub-meshes by setting the mask array, instead of dropping triangles (by <gh-user:jeertmans>, in <gh-pr:287>).
+- Added a new optional `active_triangles: Array | None = None` parameter to {func}`rays_intersect_any_triangle<differt.rt.rays_intersect_any_triangle>`, `triangles_visible_from_vertices<differt.rt.triangles_visible_from_vertices>`, and `first_triangles_hit_by_rays<differt.rt.first_triangles_hit_by_rays>` (by <gh-user:jeertmans>, in <gh-pr:287>).
+
 <!-- start changelog -->
 
 ## [0.1.2](https://github.com/jeertmans/DiffeRT/compare/v0.1.1...v0.1.2)

--- a/differt/tests/benchmarks/test_training.py
+++ b/differt/tests/benchmarks/test_training.py
@@ -30,17 +30,17 @@ def random_tx_rx(
     )
 
 
+@eqx.filter_jit
 def random_scene(
     base_scene: TriangleScene, num_tx: int = 4, num_rx: int = 8, *, key: PRNGKeyArray
 ) -> TriangleScene:
     key_tx_rx, key_num_objects, key_sample_triangles = jax.random.split(key, 3)
     scene = random_tx_rx(base_scene, num_tx, num_rx, key=key_tx_rx)
-    num_objects = scene.mesh.num_objects
-    num_objects = jax.random.randint(key_num_objects, (), 0, num_objects + 1)
+    fill_factor = jax.random.uniform(key_num_objects, ())
     return eqx.tree_at(
         lambda s: s.mesh,
         scene,
-        scene.mesh.sample(int(num_objects), key=key_sample_triangles),
+        scene.mesh.sample(fill_factor, by_masking=True, key=key_sample_triangles),
     )
 
 


### PR DESCRIPTION
This should enable better execution time in code that requires generating meshes of different sizes, as using a mask allows to JIT-compile this function (when using a fill factor instead of a static size) and to stack multiple meshes into one. Masks should be transparent to users, and not impact the final output of Ray Tracing utilities.
