### PR TITLE
chore(lib): refactor `__version__` and add `__version_info__` tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ with one *slight* but **important** difference:
 - Added {attr}`TriangleMesh.mask<differt.geometry.TriangleMesh.mask>` attribute has been added to allow triangles to be selected using a mask instead of dropping the inactive ones. This is useful for generating multiple sub-meshes of a mesh without changing the memory allocated to each sub-mesh, thus enabling efficient stacking (by <gh-user:jeertmans>, in <gh-pr:287>).
 - Added a new `by_masking: bool = False` keyword-only parameter to {meth}`TriangleMesh.sample<differt.geometry.TriangleMesh.sample>` to allow sampling sub-meshes by setting the mask array, instead of dropping triangles (by <gh-user:jeertmans>, in <gh-pr:287>).
 - Added a new optional `active_triangles: Array | None = None` parameter to {func}`rays_intersect_any_triangle<differt.rt.rays_intersect_any_triangle>`, `triangles_visible_from_vertices<differt.rt.triangles_visible_from_vertices>`, and `first_triangles_hit_by_rays<differt.rt.first_triangles_hit_by_rays>` (by <gh-user:jeertmans>, in <gh-pr:287>).
+- Added `__version_info__` tuple to {mod}`differt` and {mod}`differt_core` (by <gh-user:jeertmans>, in <gh-pr:288>).
+
+### Fixed
+
+- Fixed `__all__` in {mod}`differt` to re-export `__version__` and not `VERSION` (by <gh-user:jeertmans>, in <gh-pr:288>).
 
 <!-- start changelog -->
 

--- a/differt-core/python/differt_core/__init__.py
+++ b/differt-core/python/differt_core/__init__.py
@@ -13,6 +13,12 @@ so that one can use :mod:`differt_core` and still be able to differentiate
 its code. We welcome any contribution on that topic!
 """
 
-__all__ = ("__version__",)
+from differt_core._differt_core import __version__ as _version
+from differt_core._differt_core import __version_info__ as _version_info
 
-from differt_core._differt_core import __version__
+__all__ = ("__version__", "__version_info__")
+
+__version__ = _version
+"""The current full version of this module."""
+__version_info__ = _version_info
+"""The current short version of this module as a tuple (major, minor, patch)."""

--- a/differt-core/python/differt_core/_differt_core/__init__.pyi
+++ b/differt-core/python/differt_core/_differt_core/__init__.pyi
@@ -1,6 +1,7 @@
 from types import ModuleType
 
 __version__: str
+__version_info__: tuple[int, int, int]
 
 geometry: ModuleType
 rt: ModuleType

--- a/differt-core/src/lib.rs
+++ b/differt-core/src/lib.rs
@@ -13,6 +13,12 @@ fn _differt_core(m: Bound<'_, PyModule>) -> PyResult<()> {
     let mut version = env!("CARGO_PKG_VERSION").to_string();
     version = version.replace("-alpha", "a").replace("-beta", "b");
     m.add("__version__", version)?;
+    let version_info = (
+        env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().unwrap(),
+        env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().unwrap(),
+        env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().unwrap(),
+    );
+    m.add("__version_info__", version_info)?;
     m.add_wrapped(wrap_pymodule!(geometry::geometry))?;
     m.add_wrapped(wrap_pymodule!(rt::rt))?;
     m.add_wrapped(wrap_pymodule!(scene::scene))?;

--- a/differt-core/tests/test_version.py
+++ b/differt-core/tests/test_version.py
@@ -1,0 +1,8 @@
+import differt_core
+
+
+def test_version() -> None:
+    assert (
+        tuple(int(i) for i in differt_core.__version__.split(".")[:3])
+        == differt_core.__version_info__
+    )

--- a/differt/src/differt/__init__.py
+++ b/differt/src/differt/__init__.py
@@ -1,6 +1,8 @@
 """Differentiable Ray Tracing Toolbox for Radio Propagation."""
 
-from ._version import VERSION
+from ._version import __version__, __version_info__
 
-__version__ = VERSION
-__all__ = ("VERSION",)
+__all__ = (
+    "__version__",
+    "__version_info__",
+)

--- a/differt/src/differt/_version.py
+++ b/differt/src/differt/_version.py
@@ -1,6 +1,6 @@
-from differt_core import __version__  # Re-export version from code module
+from differt_core import (  # Re-export version from core module
+    __version__,
+    __version_info__,
+)
 
-__all__ = ("VERSION",)
-
-VERSION: str = __version__
-"""The current version of this module."""
+__all__ = ("__version__", "__version_info__")

--- a/differt/tests/test_differt_core.py
+++ b/differt/tests/test_differt_core.py
@@ -4,3 +4,4 @@ import differt_core
 
 def test_same_version() -> None:
     assert differt.__version__ == differt_core.__version__
+    assert differt.__version_info__ == differt_core.__version_info__


### PR DESCRIPTION
Capitalized variables are now removed.