### PR TITLE
perf(lib): faster ray-triangle intersection tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,24 @@ with one *slight* but **important** difference:
 
 ## [Unreleased](https://github.com/jeertmans/DiffeRT/compare/v0.4.0...HEAD)
 
+### Added
+
+- Added `batch_size` optional keyword argument to {func}`rays_intersect_any_triangle<differt.rt.rays_intersect_any_triangle>`, {func}`triangles_visible_from_vertices<differt.rt.triangles_visible_from_vertices>`, and {func}`first_triangles_hit_by_rays<differt.rt.first_triangles_hit_by_rays>`, see [below](#ray-triangle-perf-1) (by <gh-user:jeertmans>, in <gh-pr:300>).
+
 ### Chore
 
 - Refactored {func}`image_method<differt.rt.image_method>` and {func}`fermat_path_on_linear_objects<differt.rt.fermat_path_on_linear_objects>` to use {func}`jnp.vectorize<jax.numpy.vectorize>` instead of a custom but complex chain of calls to {func}`jax.vmap`, reducing the code complexity while not affecting performance (by <gh-user:jeertmans>, in <gh-pr:298>).
 - Ignored lints PLR091* globally, instead of per-case (by <gh-user:jeertmans>, in <gh-pr:298>).
 - Improved code coverage for ray-triangle intersection tests (by <gh-user:jeertmans>, in <gh-pr:301>).
 - Refactored benchmarks to reduce the number of benchmarks and avoid depending on JIT compilation (by <gh-user:jeertmans>, in <gh-pr:301>).
+
+### Fixed
+
+- Fixed VisPy plotting utilities by returning early if the data to be drawn is empty, avoiding potential issue when calling {meth}`view.camera.set_range<vispy.scene.cameras.base_camera.BaseCamera.set_range>` (by <gh-user:jeertmans>, in <gh-pr:300>).
+
+### Perf
+
+- [Improved performance for ray-triangle intersection tests]{#ray-triangle-perf-1} (i.e, {func}`rays_intersect_any_triangle<differt.rt.rays_intersect_any_triangle>`, {func}`triangles_visible_from_vertices<differt.rt.triangles_visible_from_vertices>`, and {func}`first_triangles_hit_by_rays<differt.rt.first_triangles_hit_by_rays>`) by implementing a custom, batched, scan-like check. This avoids having to loop over all triangles (or rays) sequentially while preventing out-of-memory issues. A new `batch_size` argument is now available for these functions, allowing users to customize the size of each batch (by <gh-user:jeertmans>, in <gh-pr:300>).
 
 <!-- start changelog -->
 

--- a/differt/src/differt/em/_antenna.py
+++ b/differt/src/differt/em/_antenna.py
@@ -645,7 +645,7 @@ class RadiationPattern(BaseAntenna):
 
         r = self.center + distance * jnp.stack((x, y, z), axis=-1)
 
-        s = self.poynting_vector(r)  # type: ignore[reportAttributeAccessIssue]
+        s = self.poynting_vector(r)
 
         p = jnp.linalg.norm(s, axis=-1, keepdims=True)
 

--- a/differt/src/differt/geometry/_triangle_mesh.py
+++ b/differt/src/differt/geometry/_triangle_mesh.py
@@ -248,6 +248,11 @@ class TriangleMesh(eqx.Module):
 
         Unless specified, the transformation or selection operations, like :meth:`rotate`,
         will not take the mask into account, and will apply to all triangles.
+
+    .. important::
+
+        When :attr:`assume_quads` is :data:`True`, a quad is considered active if both triangles
+        that form the quad are active.
     """
 
     def __check_init__(self) -> None:  # noqa: PLW3201

--- a/differt/src/differt/plotting/_core.py
+++ b/differt/src/differt/plotting/_core.py
@@ -99,10 +99,14 @@ def _(
 
     canvas, view = process_vispy_kwargs(kwargs)
 
+    if vertices.size == 0 or triangles.size == 0:  # type: ignore[reportAttributeAccessIssue]  # pragma: no cover
+        return canvas
+
     kwargs.setdefault("shading", "flat")
 
     vertices = np.asarray(vertices)
     triangles = np.asarray(triangles)
+
     view.add(Mesh(vertices=vertices, faces=triangles, **kwargs))
     view.camera.set_range()
 
@@ -202,6 +206,9 @@ def _(
 
     canvas, view = process_vispy_kwargs(kwargs)
 
+    if paths.size == 0:  # type: ignore[reportAttributeAccessIssue]  # pragma: no cover
+        return canvas
+
     kwargs.setdefault("width", 3.0)
     kwargs.setdefault("marker_size", 0.0)
     paths = np.asarray(paths)
@@ -211,7 +218,6 @@ def _(
     connect[path_length - 1 :: path_length] = False
 
     view.add(LinePlot(data=paths, connect=connect, **kwargs))  # type: ignore[reportArgumentType]
-
     view.camera.set_range()
 
     return canvas
@@ -353,6 +359,9 @@ def _(
 
     canvas, view = process_vispy_kwargs(kwargs)
 
+    if ray_origins.size == 0 or ray_directions.size == 0:  # type: ignore[reportAttributeAccessIssue]  # pragma: no cover
+        return canvas
+
     kwargs.setdefault("width", 3.0)
     kwargs.setdefault("arrow_size", 6.0)
 
@@ -370,7 +379,6 @@ def _(
     arrows = np.concatenate((body_ends, arrows_center), axis=-1)
 
     view.add(Arrow(pos=pos, connect=connect, arrows=arrows, **kwargs))  # type: ignore[reportArgumentType]
-
     view.camera.set_range()
 
     return canvas
@@ -512,6 +520,10 @@ def _(
     from vispy.scene.visuals import Markers, Text  # noqa: PLC0415
 
     canvas, view = process_vispy_kwargs(kwargs)
+
+    if markers.size == 0:  # type: ignore[reportAttributeAccessIssue]  # pragma: no cover
+        return canvas
+
     kwargs.setdefault("size", 1)
     kwargs.setdefault("edge_width_rel", 0.05)
     kwargs.setdefault("scaling", "scene")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,6 +147,7 @@ myst_heading_anchors = 3
 
 myst_enable_extensions = [
     "amsmath",
+    "attrs_inline",
     "colon_fence",
     "dollarmath",
     "html_admonition",


### PR DESCRIPTION
Triangles / rays are grouped by `batch_size` to (possibly) accelerate the scan procedure. Moreover, `jax.lax.dynamic_slice_in_dim` is used to avoid having to reshape the arrays the have the `batched` dimension as the first dimension (required by `jax.lax.scan`).

See https://github.com/jax-ml/jax/discussions/30470

---

*Comments*

For an unknown reason (maybe the machine on which CI runs), the CodSpeed benchmarks report a regression for some tests, while I cannot reproduce this locally. All my tests show a significant improvement for related benchmarks. See timings on my machine:

**Before**

```
                                   Benchmark Results                                   
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┓
┃                        Benchmark ┃     Time (best) ┃ Rel. StdDev ┃ Run time ┃ Iters ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━┩
│                test_image_method │        87,736ns │       16.8% │    3.00s │ 8,850 │
│                      test_fermat │    86,295,515ns │        2.9% │    2.90s │    32 │
│ test_rays_intersect_any_triangle │   168,445,920ns │        7.6% │    2.62s │    14 │
│      test_transmitter_visibility │   586,894,693ns │        1.6% │    2.39s │     4 │
│ test_first_triangles_hit_by_rays │   310,131,980ns │        4.9% │    2.98s │     9 │
│   test_compute_paths[exhaustive] │     6,087,314ns │        7.9% │    3.00s │   440 │
│       test_compute_paths[hybrid] │ 2,727,340,928ns │        0.0% │    2.73s │     1 │
│                  test_train_step │     1,443,286ns │        8.4% │    2.80s │ 1,686 │
└──────────────────────────────────┴─────────────────┴─────────────┴──────────┴───────┘
```

**After**

```
                                  Benchmark Results                                  
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┓
┃                        Benchmark ┃   Time (best) ┃ Rel. StdDev ┃ Run time ┃ Iters ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━┩
│                test_image_method │      87,710ns │       18.9% │    2.89s │ 8,238 │
│                      test_fermat │  85,544,866ns │        2.6% │    2.75s │    31 │
│ test_rays_intersect_any_triangle │ 170,510,130ns │        8.9% │    2.44s │    13 │
│      test_transmitter_visibility │ 101,174,437ns │        3.6% │    2.88s │    27 │
│ test_first_triangles_hit_by_rays │ 268,347,521ns │        2.9% │    2.52s │     9 │
│   test_compute_paths[exhaustive] │   4,729,915ns │        7.5% │    2.94s │   540 │
│       test_compute_paths[hybrid] │ 633,988,360ns │        3.1% │    2.66s │     4 │
│                  test_train_step │   1,535,796ns │       16.0% │    3.00s │ 1,708 │
└──────────────────────────────────┴───────────────┴─────────────┴──────────┴───────┘
```

In the future, we might want to better fine-tune the default value for `batch_size` (here it was chosen to maximize the above performance).
