### PR TITLE
fix(lib): return correct shape in fast path

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ build:
 sphinx:
   builder: html
   configuration: docs/source/conf.py
-  fail_on_warning: false  # TODO: enable me
+  fail_on_warning: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ with one *slight* but **important** difference:
 
 ## [Unreleased](https://github.com/jeertmans/DiffeRT/compare/v0.4.1...HEAD)
 
+### Fixed
+
+- Fixed a shape (and possibly `dtype`) issue in the fast path of {func}`consecutive_vertices_are_on_same_side_of_mirrors<differt.rt.consecutive_vertices_are_on_same_side_of_mirrors>`, that would raise an error when trying to stack arrays in {meth}`TriangleScene.compute_paths<differt.scene.TriangleScene.compute_paths>` with a non-{data}`None` value for `smoothing_factor` (by <gh-user:jeertmans>, in <gh-pr:303>).
+
 <!-- start changelog -->
 
 ## [0.4.1](https://github.com/jeertmans/DiffeRT/compare/v0.4.0...v0.4.1)

--- a/differt/src/differt/rt/_image_method.py
+++ b/differt/src/differt/rt/_image_method.py
@@ -1,5 +1,3 @@
-# ruff: noqa: ERA001
-
 from functools import partial
 from typing import overload
 
@@ -430,12 +428,21 @@ def consecutive_vertices_are_on_same_side_of_mirrors(
 
     if mirror_vertices.shape[-2] == 0:
         # If there are no mirrors, return empty array.
-        dtype = bool if smoothing_factor is None else float
-        return jnp.empty(mirror_vertices.shape[:-1], dtype=dtype)
+        batch = jnp.broadcast_shapes(
+            vertices.shape[:-2],
+            mirror_vertices.shape[:-2],
+            mirror_normals.shape[:-2],
+        )
+        dtype = (
+            bool
+            if smoothing_factor is None
+            else jnp.result_type(vertices, mirror_vertices, mirror_normals)
+        )
+        return jnp.empty((*batch, 0), dtype=dtype)
 
     # dot_{prev,next} = <(v_{prev,next} - mirror_v), mirror_n>
 
-    # [num_mirrors]
+    # [*batch num_mirrors 3]
     d_prev = vertices[..., :-2, :] - mirror_vertices
     d_next = vertices[..., +2:, :] - mirror_vertices
 

--- a/docs/source/notebooks/coherence.ipynb
+++ b/docs/source/notebooks/coherence.ipynb
@@ -227,7 +227,7 @@
     "    n_r = jnp.sqrt(eta_r)\n",
     "\n",
     "    for order in range(3):\n",
-    "        for paths in scene_grid.compute_paths(order=order, chunk_size=1_000):\n",
+    "        for paths in scene_grid.compute_paths(order=order, chunk_size=10):\n",
     "            E_i, B_i = ant.fields(paths.vertices[..., 1, :])\n",
     "\n",
     "            if order > 0:\n",


### PR DESCRIPTION
Previously, shapes were not broadcasted which would incur an error in stacking the arrays in `compute_paths`
