### PR TITLE
fix(lib): `reuse` function from `plotting` module now updates defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ with one *slight* but **important** difference:
 ### Chore
 
 - Rephrased the documentation of methods returning shallow copies to clarify that they return new instances, and do not necessarily copy inner arrays (by <gh-user:jeertmans>, in <gh-pr:307>).
+- Fixed plotting issue in the coherence example notebook, where the scene in the second row was not plotted correctly, see [below](#fixed-update-defaults) (by <gh-user:jeertmans>, in <gh-pr:312>).
+
+### Fixed
+
+- [Fixed the update of default values in context managers]{#fixed-update-defaults} to actually merge the new values with the existing ones, instead of replacing them, allowing for the nesting multiple context manager without any surprise (by <gh-user:jeertmans>, in <gh-pr:312>).
 
 ### Perf
 

--- a/differt/src/differt/plotting/__init__.py
+++ b/differt/src/differt/plotting/__init__.py
@@ -100,6 +100,7 @@ __all__ = (
     "process_vispy_kwargs",
     "reuse",
     "set_defaults",
+    "update_defaults",
     "use",
     "view_from_canvas",
 )
@@ -123,6 +124,7 @@ from ._utils import (
     process_vispy_kwargs,
     reuse,
     set_defaults,
+    update_defaults,
     use,
     view_from_canvas,
 )

--- a/differt/tests/plotting/test_utils.py
+++ b/differt/tests/plotting/test_utils.py
@@ -7,10 +7,13 @@ import pytest
 from differt.plotting import (
     dispatch,
     get_backend,
+    process_kwargs,
     process_matplotlib_kwargs,
     process_plotly_kwargs,
     process_vispy_kwargs,
     reuse,
+    set_defaults,
+    update_defaults,
     use,
     view_from_canvas,
 )
@@ -228,3 +231,23 @@ def test_reuse(backend: str) -> None:
 
     with reuse(backend) as got:
         assert isinstance(got, expected)
+
+    with reuse(backend, pass_all_kwargs=True, a=1, b=2):
+        with reuse(backend, pass_all_kwargs=True, a=3, c=4):
+            kwargs = {}
+            process_kwargs(kwargs, backend=backend)
+            assert kwargs == {"a": 3, "b": 2, "c": 4}
+
+    with reuse(backend, pass_all_kwargs=True, a=1, b=2):
+        set_defaults()  # Clear defaults
+        with reuse(backend, pass_all_kwargs=True, a=3, c=4):
+            kwargs = {}
+            process_kwargs(kwargs, backend=backend)
+            assert kwargs == {"a": 3, "c": 4}
+
+    with reuse(backend, pass_all_kwargs=True, a=1, b=2):
+        update_defaults(b=6, e=7)
+        with reuse(backend, pass_all_kwargs=True, a=3, c=4):
+            kwargs = {}
+            process_kwargs(kwargs, backend=backend)
+            assert kwargs == {"a": 3, "b": 6, "c": 4, "e": 7}

--- a/docs/source/reference/differt.plotting.rst
+++ b/docs/source/reference/differt.plotting.rst
@@ -15,6 +15,7 @@ of plotting functions, either permanently or inside a given scope.
 
    reuse
    set_defaults
+   update_defaults
    use
 
 .. rubric:: Drawing functions


### PR DESCRIPTION
Previously, defaults were always replaced, which was would cause nested context managers to lead to surprises (especially since some built-in plotting functions contain context managers, without telling the user). This is considered to be a fix, rather than a change.
