### PR TITLE
chore(tests): allow to run test suite without `jaxtyping` enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ with one *slight* but **important** difference:
 
 - Rephrased the documentation of methods returning shallow copies to clarify that they return new instances, and do not necessarily copy inner arrays (by <gh-user:jeertmans>, in <gh-pr:307>).
 - Fixed plotting issue in the coherence example notebook, where the scene in the second row was not plotted correctly, see [below](#fixed-update-defaults) (by <gh-user:jeertmans>, in <gh-pr:312>).
+- Added `jaxtyped` Pytest marker to automatically skip tests that require jaxtyping when it is disabled (by <gh-user:jeertmans>, in <gh-pr:321>).
 
 ### Fixed
 

--- a/differt/src/differt/geometry/_utils.py
+++ b/differt/src/differt/geometry/_utils.py
@@ -494,13 +494,13 @@ def assemble_paths(
     from_vertices = jnp.asarray(from_vertices)
     intermediate_vertices = jnp.asarray(intermediate_vertices)
     if to_vertices is None:
-        batch = jnp.broadcast_shapes(
-            from_vertices.shape[:-1], intermediate_vertices.shape[:-1]
-        )
+        to_vertices = intermediate_vertices
+        del intermediate_vertices
+        batch = jnp.broadcast_shapes(from_vertices.shape[:-1], to_vertices.shape[:-1])
         return jnp.concatenate(
             (
                 jnp.broadcast_to(from_vertices[..., None, :], (*batch, 1, 3)),
-                jnp.broadcast_to(intermediate_vertices[..., None, :], (*batch, 1, 3)),
+                jnp.broadcast_to(to_vertices[..., None, :], (*batch, 1, 3)),
             ),
             axis=-2,
         )

--- a/differt/tests/em/test_utils.py
+++ b/differt/tests/em/test_utils.py
@@ -25,14 +25,29 @@ from ..utils import random_inputs
     ("lengths", "speed", "expectation"),
     [
         ((10,), (1,), does_not_raise()),
-        ((10,), (2,), pytest.raises(TypeError)),
+        pytest.param(
+            (10,),
+            (2,),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
         ((20, 10), (1,), does_not_raise()),
         ((20, 10), (10,), does_not_raise()),
         ((20, 1), (10,), does_not_raise()),
         ((20, 1), (1, 10), does_not_raise()),
         ((20, 1), (), does_not_raise()),
-        ((20, 10), (20,), pytest.raises(TypeError)),
-        ((10, 4), (10, 5), pytest.raises(TypeError)),
+        pytest.param(
+            (20, 10),
+            (20,),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
+        pytest.param(
+            (10, 4),
+            (10, 5),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
     ],
 )
 @random_inputs("lengths", "speed")
@@ -53,7 +68,11 @@ def test_lengths_to__delays_random_inputs(
     [
         ((10, 3), does_not_raise()),
         ((20, 10, 3), does_not_raise()),
-        ((10, 4), pytest.raises(TypeError)),
+        pytest.param(
+            (10, 4),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
         ((1, 3), does_not_raise()),
         ((0, 3), does_not_raise()),
     ],

--- a/differt/tests/geometry/test_triangle_mesh.py
+++ b/differt/tests/geometry/test_triangle_mesh.py
@@ -28,15 +28,17 @@ from ..utils import random_inputs
         ((1, 10, 3, 3), (20, 1, 3), does_not_raise()),
         ((10, 3, 3), (10, 3), does_not_raise()),
         ((3, 3), (3,), does_not_raise()),
-        (
+        pytest.param(
             (3, 3),
             (4,),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
-        (
+        pytest.param(
             (10, 3, 3),
             (12, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
     ],
 )
@@ -522,16 +524,22 @@ class TestTriangleMesh:
             pytest.param(
                 (30, 3),
                 pytest.raises(TypeError),
-                marks=pytest.mark.xfail(
-                    reason="Unsupported type checking of typing.Self"
-                ),
+                marks=[
+                    pytest.mark.xfail(
+                        reason="Unsupported type checking of typing.Self"
+                    ),
+                    pytest.mark.jaxtyped,
+                ],
             ),
             pytest.param(
                 (1, 24, 3),
                 pytest.raises(TypeError),
-                marks=pytest.mark.xfail(
-                    reason="Unsupported type checking of typing.Self"
-                ),
+                marks=[
+                    pytest.mark.xfail(
+                        reason="Unsupported type checking of typing.Self"
+                    ),
+                    pytest.mark.jaxtyped,
+                ],
             ),
         ],
     )

--- a/differt/tests/geometry/test_utils.py
+++ b/differt/tests/geometry/test_utils.py
@@ -33,7 +33,11 @@ from ..utils import random_inputs
     [
         ((10, 3), does_not_raise()),
         ((20, 10, 3), does_not_raise()),
-        ((10, 4), pytest.raises(TypeError)),
+        pytest.param(
+            (10, 4),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
     ],
 )
 @pytest.mark.parametrize("keepdims", [False, True])
@@ -95,7 +99,11 @@ def test_orthogonal_basis(u: Array) -> None:
     [
         ((10, 3), does_not_raise()),
         ((20, 10, 3), does_not_raise()),
-        ((10, 4), pytest.raises(TypeError)),
+        pytest.param(
+            (10, 4),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
         ((1, 3), does_not_raise()),
         ((0, 3), does_not_raise()),
     ],
@@ -226,8 +234,16 @@ def test_assemble_paths() -> None:
         (((3,), (3,)), does_not_raise()),
         (((3,), (2, 1, 3), (3,)), does_not_raise()),
         (((1, 5, 3), (10, 5, 2, 3), (3,)), does_not_raise()),
-        (((3,), (6, 4), (3,)), pytest.raises(TypeError)),
-        (((1, 3), (3,), (1, 3)), pytest.raises(TypeError)),
+        pytest.param(
+            ((3,), (6, 4), (3,)),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
+        pytest.param(
+            ((1, 3), (3,), (1, 3)),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
     ],
 )
 def test_assemble_paths_random_inputs(
@@ -239,9 +255,9 @@ def test_assemble_paths_random_inputs(
     keys = jax.random.split(key, len(shapes))
 
     from_vertices = jax.random.uniform(keys[0], shape=shapes[0])
-    to_vertices = jax.random.uniform(keys[1], shape=shapes[1])
+    to_vertices = jax.random.uniform(keys[-1], shape=shapes[-1])
     if len(shapes) == 3:
-        intermediate_vertices = jax.random.uniform(keys[2], shape=shapes[2])
+        intermediate_vertices = jax.random.uniform(keys[1], shape=shapes[1])
     else:
         intermediate_vertices = to_vertices
         to_vertices = None

--- a/differt/tests/rt/test_image_method.py
+++ b/differt/tests/rt/test_image_method.py
@@ -40,18 +40,26 @@ def test_image_of_vertices_with_respect_to_mirrors() -> None:
         ((10, 3), (10, 1, 3), (1, 1, 3), does_not_raise()),
         ((1, 3), (10, 1, 3), (1, 1, 3), does_not_raise()),
         ((3,), (1, 3), (1, 3), does_not_raise()),
-        ((20, 3), (10, 3), (10, 3), pytest.raises(TypeError)),
-        (
+        pytest.param(
+            (20, 3),
+            (10, 3),
+            (10, 3),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
+        pytest.param(
             (10, 3),
             (20, 3),
             (10, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
-        (
+        pytest.param(
             (10, 3),
             (10, 4),
             (10, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
     ],
 )
@@ -158,8 +166,22 @@ def test_intersection_of_rays_with_planes_parallel() -> None:
         ((10, 3), (10, 3), (1, 3), (1, 3), does_not_raise()),
         ((3,), (3,), (3,), (3,), does_not_raise()),
         ((10, 3), (1, 10, 3), (1, 1, 3), (10, 1, 3), does_not_raise()),
-        ((10, 3), (1, 10, 3), (1, 1, 3), (10, 2, 3), pytest.raises(TypeError)),
-        ((20, 3), (10, 3), (10, 3), (10, 3), pytest.raises(TypeError)),
+        pytest.param(
+            (10, 3),
+            (1, 10, 3),
+            (1, 1, 3),
+            (10, 2, 3),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
+        pytest.param(
+            (20, 3),
+            (10, 3),
+            (10, 3),
+            (10, 3),
+            pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
+        ),
     ],
 )
 @random_inputs("ray_origins", "ray_directions", "plane_vertices", "plane_normals")
@@ -247,23 +269,26 @@ def test_image_method_return_vertices_on_mirrors(
         ((12, 3), (10, 3), (10, 3), does_not_raise()),
         ((4, 12, 3), (10, 3), (10, 3), does_not_raise()),
         ((6, 7, 12, 3), (10, 3), (10, 3), does_not_raise()),
-        (
+        pytest.param(
             (12, 3),
             (10, 3),
             (11, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
-        (
+        pytest.param(
             (10, 3),
             (12, 4),
             (12, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
-        (
+        pytest.param(
             (12, 3),
             (11, 4),
             (11, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
     ],
 )

--- a/differt/tests/rt/test_utils.py
+++ b/differt/tests/rt/test_utils.py
@@ -197,11 +197,12 @@ def test_rays_intersect_triangles_t_and_hit() -> None:
     [
         ((3,), (3,), (3, 3), does_not_raise()),
         ((15, 5, 3), (15, 5, 3), (5, 3, 3), does_not_raise()),
-        (
+        pytest.param(
             (15, 5, 3),
             (15, 5, 3),
             (15, 3, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
     ],
 )
@@ -246,17 +247,19 @@ def test_rays_intersect_triangles_random_inputs(
         ((20, 10, 3), (20, 10, 3), (20, 10, 5, 3, 3), does_not_raise()),
         ((10, 3), (10, 3), (1, 3, 3), does_not_raise()),
         ((3,), (3,), (1, 3, 3), does_not_raise()),
-        (
+        pytest.param(
             (10, 3),
             (20, 3),
             (1, 3, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
-        (
+        pytest.param(
             (10, 3),
             (10, 4),
             (10, 3, 3),
             pytest.raises(TypeError),
+            marks=pytest.mark.jaxtyped,
         ),
     ],
 )


### PR DESCRIPTION
Previously, tests relying on runtime type checking would fail when `--jaxtyping-packages=""` was passed. Now, those tests are skipped.
