### PR TITLE
chore(deps): pin `ipykernel<7` to avoid breaking previewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ with one *slight* but **important** difference:
 - Removed PyOpenGL from macOS dependencies as it is no longer needed to fix VisPy not finding DLL files (by <gh-user:jeertmans>, in <gh-pr:345>).
 - Fix anchor link to JAX's documentation (by <gh-user:jeertmans>, in <gh-pr:346>).
 
+### Fixed
+
+- Restricted `ipykernel` version to `<7` to avoid compatibility issues with `jupyter_rfb`, see <ext-gh-issue:vispy/jupyter_rfb#121> (by <gh-user:jeertmans>, in <gh-pr:347>).
+
 <!-- start changelog -->
 
 ## [0.6.2](https://github.com/jeertmans/DiffeRT/compare/v0.6.1...v0.6.2)

--- a/differt/pyproject.toml
+++ b/differt/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.11"
 all = [
   "differt[jupyter,matplotlib,plotly,vispy,vispy-backend]",
 ]
-jupyter = ["notebook>5", "jupyter-rfb>=0.4.2", "ipympl>=0.9.4"]
+jupyter = ["notebook>5", "jupyter-rfb>=0.4.2", "ipympl>=0.9.4", "ipykernel<7"]
 matplotlib = ["matplotlib>=3.8.1"]
 plotly = ["plotly>=5.18.0"]
 vispy = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,6 +143,11 @@ myst_url_schemes = {
         "title": "@{{path}}",
         "classes": ["github"],
     },
+    "ext-gh-issue": {
+        "url": "https://github.com/{{path}}/issues/{{fragment}}",
+        "title": "Issue {{path}}#{{fragment}}",
+        "classes": ["github"],
+    },
 }
 
 myst_heading_anchors = 3

--- a/uv.lock
+++ b/uv.lock
@@ -850,6 +850,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "ipykernel" },
     { name = "ipympl" },
     { name = "jupyter-rfb" },
     { name = "matplotlib" },
@@ -859,6 +860,7 @@ all = [
     { name = "vispy" },
 ]
 jupyter = [
+    { name = "ipykernel" },
     { name = "ipympl" },
     { name = "jupyter-rfb" },
     { name = "notebook" },
@@ -883,6 +885,8 @@ requires-dist = [
     { name = "equinox", specifier = ">=0.13.1" },
     { name = "filelock", specifier = ">=3.15.4" },
     { name = "fpt-jax", specifier = "==0.1.0" },
+    { name = "ipykernel", marker = "extra == 'all'", specifier = "<7" },
+    { name = "ipykernel", marker = "extra == 'jupyter'", specifier = "<7" },
     { name = "ipympl", marker = "extra == 'all'", specifier = ">=0.9.4" },
     { name = "ipympl", marker = "extra == 'jupyter'", specifier = ">=0.9.4" },
     { name = "jax", specifier = ">=0.7.2" },


### PR DESCRIPTION
See https://github.com/vispy/jupyter_rfb/issues/121.
