### PR TITLE
chore(deps): bump Pytest to v9

### DIFF
--- a/differt/pyproject.toml
+++ b/differt/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "filelock>=3.15.4",
   "fpt-jax==0.1.0",
   "jax>=0.7.2",
-  "jaxtyping>=0.3.2",
+  "jaxtyping>=0.3.6",
   "numpy>=1.26.1",
   "requests>=2.32.0",
   "tqdm>=4.66.2",

--- a/differt/src/differt/plotting/_utils.py
+++ b/differt/src/differt/plotting/_utils.py
@@ -16,6 +16,7 @@ from typing import (
     TypeVar,
     get_args,
     no_type_check,
+    runtime_checkable,
 )
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ class _Defaults:
     kwargs: dict[str, Any] = field(default_factory=dict)
 
 
-@no_type_check  # TODO: fixme, Beartype >=0.20.1 is not happy with RLock
+@no_type_check
 @dataclass(slots=True)
 class _Config:
     lock: RLock = field(default_factory=RLock)
@@ -270,6 +271,7 @@ def use(backend: LiteralString | None = None, **kwargs: Any) -> Iterator[Backend
             pass
 
 
+@runtime_checkable
 class _Dispatcher(Protocol[P, T]):
     registry: types.MappingProxyType[str, Callable[P, T]]
 

--- a/differt/tests/conftest.py
+++ b/differt/tests/conftest.py
@@ -88,7 +88,7 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    if "differt" in config.getoption("--jaxtyping-packages", default=""):
+    if (option := config.getoption("--jaxtyping-packages")) and "differt" in option:
         return
     skip_jaxtyping = pytest.mark.skip(
         reason='need --jaxtyping-packages="differt,..." option to run'

--- a/docs/source/notebooks/performance_tips.ipynb
+++ b/docs/source/notebooks/performance_tips.ipynb
@@ -247,7 +247,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "14",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "from beartype import beartype as typechecker\n",
@@ -261,6 +269,9 @@
     "z = jax.random.uniform(key3, batch)\n",
     "\n",
     "# Don't do this!\n",
+    "# N.B.: as of jaxtyping v0.3.3, an error is now raised when the @jax.jit decorator is\n",
+    "# placed first. Prior to this version, placing the @jax.jit decorator under the\n",
+    "# @jaxtyped would lead to a performance decrease (see the next cell)\n",
     "\n",
     "\n",
     "@jaxtyped(typechecker=typechecker)\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,15 +51,15 @@ tests = [
   {include-group = "beartype"},
   "differt",
   "chex>=0.1.84",
-  "pytest>=7.4.3,<8.3.5",
+  "pytest>=9.0.2",
   "pytest-benchmark>=4.0.0",
   "pytest-cov>=4.1.0",
   "pytest-env>=1.1.3",
   "pytest-missing-modules>=0.2.0",
   "pytest-subtests>=0.14.1",
   "pytest-xdist>=3.3.1",
-  "scipy>=1.12.0",
   "optax>=0.2.6",
+  "scipy>=1.12.0",
 ]
 tests-extended = [
   {include-group = "sionna"},
@@ -192,7 +192,7 @@ precision = 2
 [tool.coverage.run]
 omit = ["**/*/conftest.py"]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = [
   "--jaxtyping-packages=differt,beartype.beartype(conf=beartype.BeartypeConf(strategy=beartype.BeartypeStrategy.On))",
   "--numprocesses=logical",
@@ -225,6 +225,7 @@ markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
   "serial",
 ]
+minversion = "9.0"
 
 [tool.ruff]
 extend-include = ["*.ipynb"]

--- a/uv.lock
+++ b/uv.lock
@@ -890,7 +890,7 @@ requires-dist = [
     { name = "ipympl", marker = "extra == 'all'", specifier = ">=0.9.4" },
     { name = "ipympl", marker = "extra == 'jupyter'", specifier = ">=0.9.4" },
     { name = "jax", specifier = ">=0.7.2" },
-    { name = "jaxtyping", specifier = ">=0.3.2" },
+    { name = "jaxtyping", specifier = ">=0.3.6" },
     { name = "jupyter-rfb", marker = "extra == 'all'", specifier = ">=0.4.2" },
     { name = "jupyter-rfb", marker = "extra == 'jupyter'", specifier = ">=0.4.2" },
     { name = "matplotlib", marker = "extra == 'all'", specifier = ">=3.8.1" },
@@ -1089,7 +1089,7 @@ dev = [
     { name = "pillow", specifier = ">=10.1.0" },
     { name = "plotly", specifier = "<6" },
     { name = "pre-commit", specifier = ">=3.5.0" },
-    { name = "pytest", specifier = ">=7.4.3,<8.3.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-codspeed", specifier = ">=2.2.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -1143,7 +1143,7 @@ tests = [
     { name = "chex", specifier = ">=0.1.84" },
     { name = "differt", editable = "differt" },
     { name = "optax", specifier = ">=0.2.6" },
-    { name = "pytest", specifier = ">=7.4.3,<8.3.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=1.1.3" },
@@ -1159,7 +1159,7 @@ tests-extended = [
     { name = "differt", extras = ["all"], editable = "differt" },
     { name = "open3d-cpu", marker = "python_full_version < '3.13' and sys_platform == 'linux'", specifier = ">=0.19.0" },
     { name = "optax", specifier = ">=0.2.6" },
-    { name = "pytest", specifier = ">=7.4.3,<8.3.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=1.1.3" },
@@ -1175,7 +1175,7 @@ tests-matplotlib = [
     { name = "differt", editable = "differt" },
     { name = "differt", extras = ["matplotlib"], editable = "differt" },
     { name = "optax", specifier = ">=0.2.6" },
-    { name = "pytest", specifier = ">=7.4.3,<8.3.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=1.1.3" },
@@ -1190,7 +1190,7 @@ tests-plotly = [
     { name = "differt", editable = "differt" },
     { name = "differt", extras = ["plotly"], editable = "differt" },
     { name = "optax", specifier = ">=0.2.6" },
-    { name = "pytest", specifier = ">=7.4.3,<8.3.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=1.1.3" },
@@ -1205,7 +1205,7 @@ tests-vispy = [
     { name = "differt", editable = "differt" },
     { name = "differt", extras = ["vispy", "vispy-backend"], editable = "differt" },
     { name = "optax", specifier = ">=0.2.6" },
-    { name = "pytest", specifier = ">=7.4.3,<8.3.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=1.1.3" },
@@ -2198,14 +2198,14 @@ wheels = [
 
 [[package]]
 name = "jaxtyping"
-version = "0.3.2"
+version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wadler-lindig" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/a8/416bd7ea110ec6b68e8868b0f99c985c735adcf7badc491d3c343937260a/jaxtyping-0.3.2.tar.gz", hash = "sha256:f30483fac4b42e915db8ad2414a85c3b63284aa7d3c100b96b59f755cf4a86ad", size = 44989, upload-time = "2025-04-23T09:48:16.907Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/25/0b2c2cd048fe03561d3ed8aa9d0242903606c31ee0ef329b2adae79ebc79/jaxtyping-0.3.6.tar.gz", hash = "sha256:88e5450c96a1bcaf37c74ae5ef60084b5d307727a198d31cc7eaeba9db3f42e7", size = 45681, upload-time = "2026-01-24T17:37:48.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/b9/281e10e2d967ea5e481683eaec99f55ac5a61085ee60551c36942ef32bef/jaxtyping-0.3.2-py3-none-any.whl", hash = "sha256:6a020fd276226ddb5ac4f5725323843dd65e3c7e85c64fd62431e5f738c74e04", size = 55409, upload-time = "2025-04-23T09:48:15.924Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/87/944bcf3cb5b82a1f7fb86e825e866eb3a72220d4bb0f2c163d7b122772f2/jaxtyping-0.3.6-py3-none-any.whl", hash = "sha256:179df02f6b5b704d2ebafd1946cc857e745b489328d668ff4f8555b02e8aa944", size = 56053, upload-time = "2026-01-24T17:37:46.472Z" },
 ]
 
 [[package]]
@@ -4181,17 +4181,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919, upload-time = "2024-12-01T12:54:25.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083, upload-time = "2024-12-01T12:54:19.735Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR requires either:
- https://github.com/patrick-kidger/jaxtyping/issues/368
or
- https://github.com/patrick-kidger/jaxtyping/pull/369
or
- `beartype` v0.23 is released (https://github.com/beartype/beartype/issues/611#issuecomment-3753099335)